### PR TITLE
Implement basic context.getOptions() support

### DIFF
--- a/lib/LoaderRunner.js
+++ b/lib/LoaderRunner.js
@@ -324,6 +324,11 @@ exports.runLoaders = function runLoaders(options, callback) {
 		missingDependencies.length = 0;
 		requestCacheable = true;
 	};
+	loaderContext.getOptions = function getOptions() {
+		// TODO support and validate schema option?
+		var entry = loaderContext.loaders[loaderContext.loaderIndex];
+		return entry.options && typeof entry.options === "object" ? entry.options : {};
+	};
 	Object.defineProperty(loaderContext, "resource", {
 		enumerable: true,
 		get: function() {

--- a/test/fixtures/echo-options-loader.js
+++ b/test/fixtures/echo-options-loader.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+	return JSON.stringify(this.getOptions());
+};

--- a/test/runLoaders.js
+++ b/test/runLoaders.js
@@ -725,4 +725,39 @@ describe("runLoaders", function() {
 			done();
 		});
 	});
+	it("should make getOptions available to loaders", function(done) {
+		runLoaders(
+			{
+				resource: path.resolve(fixtures, "resource.bin"),
+				loaders: [
+					{
+						loader: path.resolve(fixtures, "echo-options-loader.js"),
+						options: {
+							foo: "bar",
+						},
+					},
+				],
+			},
+			(err, result) => {
+				if(err) return done(err);
+				result.result.should.be.eql(["{\"foo\":\"bar\"}"]);
+				done();
+			}
+		);
+	});
+	it("should default to empty getOptions if none provided", function(done) {
+		runLoaders(
+			{
+				resource: path.resolve(fixtures, "resource.bin"),
+				loaders: [
+					path.resolve(fixtures, "echo-options-loader.js"),
+				],
+			},
+			(err, result) => {
+				if(err) return done(err);
+				result.result.should.be.eql(["{}"]);
+				done();
+			}
+		);
+	});
 });


### PR DESCRIPTION
This implements a basic form of the webpack 5 loader api `getOptions()`

It:

* Returning the options object passed along with the loader when `runLoaders` is invoked with `{loader, options}` pairs. Otherwise, it returns an empty object.
* Does not implement the schema validation that the webpack implementation does [0]
* Does not support parsing string options like the webpack implementation does, as the api for `runLoaders` already accepts an object.

Test Plan: Added two tests.

[0] https://github.com/webpack/webpack/blob/d673e4179b42144683b79db9ae8244858aeda220/lib/NormalModule.js#L393
